### PR TITLE
Skip preprare and QC if output already exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,9 +100,41 @@ jobs:
                           --space MNI152NLin2009cAsym \
                           --reset_database \
                           -vv
-                no_output_timeout: 6h
+        -   run:
+                name: rerun prepare - fast as output already exists
+                command: |
+                    user_name=cpplab
+                    repo_name=$(echo "${CIRCLE_PROJECT_REPONAME}" | tr '[:upper:]' '[:lower:]')
+                    docker run -ti --rm \
+                      -v /tmp/workspace/data/ds002799/derivatives/fmriprep:/bids_dataset \
+                      -v ${HOME}/outputs:/outputs \
+                        ${user_name}/${repo_name} \
+                          /bids_dataset \
+                          /outputs \
+                          participant \
+                          prepare \
+                          --participant_label 302 307 \
+                          --space MNI152NLin2009cAsym \
+                          --reset_database \
+                          -vv
+        -   run:
+                name: run group level QC
+                command: |
+                    user_name=cpplab
+                    repo_name=$(echo "${CIRCLE_PROJECT_REPONAME}" | tr '[:upper:]' '[:lower:]')
+                    docker run -ti --rm \
+                      -v ${HOME}/outputs:/outputs \
+                        ${user_name}/${repo_name} \
+                          /outputs/bidsmreye \
+                          /outputs \
+                          group \
+                          qc \
+                          --participant_label 302 307 \
+                          --space MNI152NLin2009cAsym \
+                          --reset_database \
+                          -vv
         -   store_artifacts:
-                path: ~/output
+                path: ${HOME}/outputs/bidsmreye
 
     deploy:
         machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
                           --reset_database \
                           -vv
         -   store_artifacts:
-                path: ${HOME}/outputs/bidsmreye
+                path: /home/circleci/outputs/bidsmreye
 
     deploy:
         machine:

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -23,7 +23,6 @@ jobs:
         strategy:
             matrix:
                 python-version: ['3.11']
-                dataset: [demo]
 
         steps:
 
@@ -50,8 +49,10 @@ jobs:
             run: |
                 datalad wtf
 
-        -   name: Run ${{ matrix.dataset }}
-            run: make ${{ matrix.dataset }}
+        -   name: Run demo
+            run: make demo
 
-        -   name: Re run ${{ matrix.dataset }} (should be faster)
-            run: make ${{ matrix.dataset }}
+        -   name: Re run demo (should be faster)
+            run: |
+                make prepare
+                make generalize

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -52,3 +52,6 @@ jobs:
 
         -   name: Run ${{ matrix.dataset }}
             run: make ${{ matrix.dataset }}
+
+        -   name: Re run ${{ matrix.dataset }} (should be faster)
+            run: make ${{ matrix.dataset }}

--- a/Makefile
+++ b/Makefile
@@ -185,10 +185,45 @@ ds002799: clean-ds002799 get_ds002799
 				--reset_database \
 				-vv
 
-## ds002799
+## ds000114
 get_ds000114:
 	datalad install -s ///openneuro-derivatives/ds000114-fmriprep tests/data/ds000114-fmriprep
 	cd tests/data/ds000114-fmriprep && datalad get sub-0[1-2]/ses-*/func/*MNI*desc-preproc*bold.nii.gz -J 12
+
+ds000114_all: get_ds000114
+	bidsmreye 	$$PWD/tests/data/ds000114-fmriprep \
+				$$PWD/outputs/ds000114/derivatives \
+				participant \
+				all \
+				--participant_label 01 02 \
+				--space MNI152NLin2009cAsym \
+				--task linebisection overtverbgeneration -vv --force
+
+ds000114_prepare: get_ds000114
+	bidsmreye 	$$PWD/tests/data/ds000114-fmriprep \
+				$$PWD/outputs/ds000114/derivatives \
+				participant \
+				prepare \
+				--participant_label 01 02 \
+				--space MNI152NLin2009cAsym \
+				--task linebisection -vv
+
+ds000114_generalize:
+	bidsmreye 	$$PWD/tests/data/ds000114-fmriprep \
+				$$PWD/outputs/ds000114/derivatives \
+				participant \
+				generalize \
+				--participant_label 01 02 \
+				--space MNI152NLin2009cAsym
+
+ds000114_qc:
+	bidsmreye 	$$PWD/outputs/ds000114/derivatives/bidsmreye \
+				$$PWD/outputs/ds000114/derivatives \
+				group \
+				qc \
+				--participant_label 01 02 \
+				--space MNI152NLin2009cAsym \
+				-vvv
 
 ## DOCKER
 .PHONY:

--- a/bidsmreye/_cli.py
+++ b/bidsmreye/_cli.py
@@ -39,7 +39,7 @@ def cli(argv: Any = sys.argv) -> None:
 
     model_weights_file = None
     if getattr(args, "model", None) is not None:
-        model_weights_file = str(getattr(args, "model"))
+        model_weights_file = str(getattr(args, "model"))  # noqa: B009
 
     bidsmreye(
         bids_dir=args.bids_dir[0],
@@ -56,6 +56,7 @@ def cli(argv: Any = sys.argv) -> None:
         bids_filter_file=args.bids_filter_file,
         non_linear_coreg=bool(getattr(args, "non_linear_coreg", False)),
         log_level_name=log_level_name,
+        force=bool(getattr(args, "force", False)),
     )
 
 

--- a/bidsmreye/_parsers.py
+++ b/bidsmreye/_parsers.py
@@ -240,7 +240,7 @@ Model to download.
         help="""
 The directory where the model files will be stored.
         """,
-        default=Path.cwd().joinpath("models"),
+        default=Path.cwd() / "models",
     )
 
     return parser

--- a/bidsmreye/_parsers.py
+++ b/bidsmreye/_parsers.py
@@ -127,6 +127,13 @@ A JSON file describing custom BIDS input filters using PyBIDS.
 For further details, please check out TBD.
         """,
     )
+    parser.add_argument(
+        "--force",
+        help="""
+Overwrite previous output.
+        """,
+        action="store_true",
+    )
     return parser
 
 

--- a/bidsmreye/bids_utils.py
+++ b/bidsmreye/bids_utils.py
@@ -121,7 +121,7 @@ def create_bidsname(
 
     output_file = Path(layout.root).joinpath(output_file)
 
-    return output_file.resolve()
+    return output_file.absolute()
 
 
 def create_sidecar(
@@ -180,7 +180,7 @@ def get_dataset_layout(
         dataset_path = Path(dataset_path)
     create_dir_if_absent(dataset_path)
 
-    dataset_path = dataset_path.resolve()
+    dataset_path = dataset_path.absolute()
 
     pybids_config = config
     if config is None:

--- a/bidsmreye/bids_utils.py
+++ b/bidsmreye/bids_utils.py
@@ -119,8 +119,7 @@ def create_bidsname(
 
     output_file = layout.build_path(entities, bids_name_config[filetype], validate=False)
 
-    output_file = Path(layout.root).joinpath(output_file)
-
+    output_file = Path(layout.root) / output_file
     return output_file.absolute()
 
 
@@ -193,7 +192,7 @@ def get_dataset_layout(
             dataset_path, validate=False, derivatives=False, config=pybids_config
         )
 
-    database_path = dataset_path.joinpath("pybids_db")
+    database_path = dataset_path / "pybids_db"
     return BIDSLayout(
         dataset_path,
         validate=False,
@@ -321,7 +320,7 @@ def write_dataset_description(layout: BIDSLayout) -> None:
     :param layout: BIDSLayout of the dataset to update.
     :type layout: BIDSLayout
     """
-    output_file = Path(layout.root).joinpath("dataset_description.json")
+    output_file = Path(layout.root) / "dataset_description.json"
 
     with open(output_file, "w") as ff:
         json.dump(layout.dataset_description, ff, indent=4)

--- a/bidsmreye/bidsmreye.py
+++ b/bidsmreye/bidsmreye.py
@@ -29,6 +29,7 @@ def bidsmreye(
     bids_filter_file: str | None = None,
     non_linear_coreg: bool = False,
     log_level_name: str | None = None,
+    force: bool = False,
 ) -> None:
     bids_filter = None
     if bids_filter_file is not None and Path(bids_filter_file).is_file():
@@ -50,6 +51,7 @@ def bidsmreye(
         reset_database=reset_database,
         bids_filter=bids_filter,
         non_linear_coreg=non_linear_coreg,
+        force=force,
     )  # type: ignore
 
     if log_level_name is None:

--- a/bidsmreye/configuration.py
+++ b/bidsmreye/configuration.py
@@ -31,14 +31,14 @@ class Config:
     def _check_input_dir(self, attribute: str, value: Path) -> None:
         if not value.is_dir:  # type: ignore
             raise ValueError(
-                f"input_dir must be an existing directory:\n{value.resolve()}."
+                f"input_dir must be an existing directory:\n{value.absolute()}."
             )
 
         if not value.joinpath("dataset_description.json").is_file():
             raise ValueError(
                 f"""input_dir does not seem to be a valid BIDS dataset.
 No dataset_description.json found:
-\t{value.resolve()}."""
+\t{value.absolute()}."""
             )
 
     output_dir: Path = field(default=None, converter=Path)
@@ -55,6 +55,7 @@ No dataset_description.json found:
     debug: str | bool | None = field(kw_only=True, default=None)
     reset_database: bool = field(kw_only=True, default=False)
     non_linear_coreg: bool = field(kw_only=True, default=False)
+    force: bool = field(kw_only=True, default=False)
 
     has_GPU: bool = False
 
@@ -225,7 +226,7 @@ def get_config(config_file: Path | None = None, default: str = "") -> dict[str, 
     :rtype: dict
     """
     if config_file is None or not Path(config_file).exists():
-        my_path = Path(__file__).resolve().parent.joinpath("config")
+        my_path = Path(__file__).absolute().parent.joinpath("config")
         config_file = my_path.joinpath(default)
 
     if config_file is None or not Path(config_file).exists():

--- a/bidsmreye/configuration.py
+++ b/bidsmreye/configuration.py
@@ -34,7 +34,7 @@ class Config:
                 f"input_dir must be an existing directory:\n{value.absolute()}."
             )
 
-        if not value.joinpath("dataset_description.json").is_file():
+        if not (value / "dataset_description.json").is_file():
             raise ValueError(
                 f"""input_dir does not seem to be a valid BIDS dataset.
 No dataset_description.json found:
@@ -75,11 +75,11 @@ No dataset_description.json found:
         if not self.bids_filter:
             self.bids_filter = get_bids_filter_config()
 
-        self.output_dir = self.output_dir.joinpath("bidsmreye")
+        self.output_dir = self.output_dir / "bidsmreye"
         if not self.output_dir:
             self.output_dir.mkdir(parents=True, exist_ok=True)
 
-        database_path = self.input_dir.joinpath("pybids_db")
+        database_path = self.input_dir / "pybids_db"
 
         layout_in = BIDSLayout(
             self.input_dir,
@@ -226,8 +226,8 @@ def get_config(config_file: Path | None = None, default: str = "") -> dict[str, 
     :rtype: dict
     """
     if config_file is None or not Path(config_file).exists():
-        my_path = Path(__file__).absolute().parent.joinpath("config")
-        config_file = my_path.joinpath(default)
+        my_path = Path(__file__).absolute().parent / "config"
+        config_file = my_path / default
 
     if config_file is None or not Path(config_file).exists():
         raise FileNotFoundError(f"Config file {config_file} not found")

--- a/bidsmreye/download.py
+++ b/bidsmreye/download.py
@@ -33,7 +33,7 @@ def download(
         model_name = default_model()
     if isinstance(model_name, Path):
         assert model_name.is_file()
-        return model_name.resolve()
+        return model_name.absolute()
     if model_name not in available_models():
         warnings.warn(f"{model_name} is not a valid model name.", stacklevel=3)
         return None

--- a/bidsmreye/download.py
+++ b/bidsmreye/download.py
@@ -39,7 +39,7 @@ def download(
         return None
 
     if output_dir is None:
-        output_dir = Path.cwd().joinpath("models")
+        output_dir = Path.cwd() / "models"
     if isinstance(output_dir, str):
         output_dir = Path(output_dir)
 
@@ -48,11 +48,11 @@ def download(
         base_url="https://osf.io/download/",
         registry=None,
     )
-    source = resources.files(bidsmreye).joinpath("models/registry.txt")
+    source = resources.files(bidsmreye) / "models" / "registry.txt"
     with resources.as_file(source) as registry_file:
         POOCH.load_registry(registry_file)
 
-    output_file = output_dir.joinpath(f"dataset_{model_name}")
+    output_file = output_dir / f"dataset_{model_name}"
 
     if not output_file.is_file():
         file_idx = available_models().index(model_name)

--- a/bidsmreye/generalize.py
+++ b/bidsmreye/generalize.py
@@ -1,4 +1,4 @@
-"""TODO."""
+"""Compute eyetracking movement from preprocessed extracted data."""
 
 from __future__ import annotations
 
@@ -29,6 +29,7 @@ from bidsmreye.utils import (
     check_if_file_found,
     create_dir_for_file,
     move_file,
+    progress_bar,
     set_this_filter,
 )
 
@@ -210,9 +211,6 @@ def generalize(cfg: Config) -> None:
     :param cfg: Configuration object
     :type cfg: Config
     """
-    log.info("GENERALIZING")
-    log.info(f"Using model: {cfg.model_weights_file}")
-
     layout_out = get_dataset_layout(cfg.output_dir)
     check_layout(cfg, layout_out)
 
@@ -220,7 +218,14 @@ def generalize(cfg: Config) -> None:
 
     subjects = list_subjects(cfg, layout_out)
 
-    for subject_label in subjects:
-        process_subject(cfg, layout_out, subject_label)
+    text = "GENERALIZING"
+    with progress_bar(text=text) as progress:
+        subject_loop = progress.add_task(
+            description="processing subject", total=len(subjects)
+        )
+        log.info(f"Using model: {cfg.model_weights_file}")
+        for subject_label in subjects:
+            process_subject(cfg, layout_out, subject_label)
+            progress.update(subject_loop, advance=1)
 
     quality_control_output(cfg)

--- a/bidsmreye/generalize.py
+++ b/bidsmreye/generalize.py
@@ -131,9 +131,7 @@ def create_confounds_tsv(layout_out: BIDSLayout, file: str, subject_label: str) 
     """
     confound_numpy = create_bidsname(layout_out, file, "confounds_numpy")
 
-    source_file = Path(layout_out.root).joinpath(
-        f"sub-{subject_label}", "results_tmp.npy"
-    )
+    source_file = Path(layout_out.root) / f"sub-{subject_label}" / "results_tmp.npy"
 
     move_file(
         source_file,

--- a/bidsmreye/methods.py
+++ b/bidsmreye/methods.py
@@ -33,12 +33,12 @@ def methods(
         output_dir = Path(".")
     if isinstance(output_dir, str):
         output_dir = Path(output_dir)
-    output_dir = output_dir.joinpath("logs")
+    output_dir = output_dir / "logs"
 
-    output_file = output_dir.joinpath("CITATION.md")
+    output_file = output_dir / "CITATION.md"
     create_dir_for_file(output_file)
 
-    bib_file = str(Path(__file__).parent.joinpath("templates", "CITATION.bib"))
+    bib_file = str(Path(__file__).parent / "templates" / "CITATION.bib")
     shutil.copy(bib_file, output_dir)
 
     if not model_name:
@@ -54,7 +54,7 @@ def methods(
     if not is_known_models:
         warnings.warn(f"{model_name} is not a known model name.", stacklevel=3)
 
-    template_file = str(Path(__file__).parent.joinpath("templates", "CITATION.mustache"))
+    template_file = str(Path(__file__).parent / "templates" / "CITATION.mustache")
     with open(template_file) as template:
         output = chevron.render(
             template=template,

--- a/bidsmreye/prepare_data.py
+++ b/bidsmreye/prepare_data.py
@@ -61,7 +61,7 @@ def coregister_and_extract_data(img: str, non_linear_coreg: bool = False) -> Non
     )
 
 
-def combine_data_with_empty_labels(layout_out: BIDSLayout, img: Path, i: int = 1) -> None:
+def combine_data_with_empty_labels(layout_out: BIDSLayout, img: Path, i: int = 1) -> Path:
     """Combine data with empty labels.
 
     :param layout_out: _description_
@@ -95,6 +95,7 @@ def combine_data_with_empty_labels(layout_out: BIDSLayout, img: Path, i: int = 1
     subj["ids"].append(([entities["subject"]] * labels.shape[0], [i] * labels.shape[0]))
 
     output_file = create_bidsname(layout_out, Path(img), "no_label")
+    file_to_move = Path(layout_out.root).joinpath("..", "bidsmreye", output_file.name)
 
     preprocess.save_data(
         output_file.name,
@@ -104,6 +105,8 @@ def combine_data_with_empty_labels(layout_out: BIDSLayout, img: Path, i: int = 1
         layout_out.root,
         center_labels=False,
     )
+
+    return file_to_move
 
 
 def process_subject(

--- a/bidsmreye/prepare_data.py
+++ b/bidsmreye/prepare_data.py
@@ -1,4 +1,4 @@
-"""Run coregistration and extract data."""
+"""Run coregistration and extract data from eye masks in MNI space."""
 
 from __future__ import annotations
 
@@ -24,6 +24,7 @@ from bidsmreye.utils import (
     check_if_file_found,
     get_deepmreye_filename,
     move_file,
+    progress_bar,
     set_this_filter,
 )
 
@@ -40,7 +41,7 @@ def coregister_and_extract_data(img: str, non_linear_coreg: bool = False) -> Non
         eyemask_small,
         eyemask_big,
         dme_template,
-        mask,
+        _,
         x_edges,
         y_edges,
         z_edges,
@@ -60,7 +61,7 @@ def coregister_and_extract_data(img: str, non_linear_coreg: bool = False) -> Non
     )
 
 
-def combine_data_with_empty_labels(layout_out: BIDSLayout, img: Path, i: int = 1) -> Path:
+def combine_data_with_empty_labels(layout_out: BIDSLayout, img: Path, i: int = 1) -> None:
     """Combine data with empty labels.
 
     :param layout_out: _description_
@@ -104,12 +105,6 @@ def combine_data_with_empty_labels(layout_out: BIDSLayout, img: Path, i: int = 1
         center_labels=False,
     )
 
-    file_to_move = Path(layout_out.root).joinpath("..", "bidsmreye", output_file.name)
-
-    move_file(file_to_move, output_file)
-
-    return output_file
-
 
 def process_subject(
     cfg: Config, layout_in: BIDSLayout, layout_out: BIDSLayout, subject_label: str
@@ -141,24 +136,46 @@ def process_subject(
     check_if_file_found(bf, this_filter, layout_in)
 
     for img in bf:
-        log.info(f"Processing file: {Path(img).name}")
+        prepapre_image(cfg, layout_in, layout_out, img)
 
-        coregister_and_extract_data(img, non_linear_coreg=cfg.non_linear_coreg)
 
-        report_name = create_bidsname(layout_out, filename=img, filetype="report")
-        deepmreye_mask_report = get_deepmreye_filename(
-            layout_in, img=img, filetype="report"
+def prepapre_image(
+    cfg: Config, layout_in: BIDSLayout, layout_out: BIDSLayout, img: str
+) -> None:
+    """Preprocess a single functional image."""
+    report_name = create_bidsname(layout_out, filename=img, filetype="report")
+    mask_name = create_bidsname(layout_out, filename=img, filetype="mask")
+    output_file = create_bidsname(layout_out, Path(img), "no_label")
+
+    if (
+        not cfg.force
+        and report_name.exists()
+        and mask_name.exists()
+        and output_file.exists()
+    ):
+        log.debug(
+            "Output for the following file already exists. "
+            "Use the '--force' option to overwrite. "
+            f"\n '{Path(img).name}'"
         )
-        move_file(deepmreye_mask_report, report_name)
+        return
 
-        mask_name = create_bidsname(layout_out, filename=img, filetype="mask")
-        deepmreye_mask_name = get_deepmreye_filename(layout_in, img=img, filetype="mask")
-        move_file(deepmreye_mask_name, mask_name)
+    log.info(f"Processing file: {Path(img).name}")
 
-        source = str(Path(img).relative_to(layout_in.root))
-        save_sampling_frequency_to_json(layout_out, img=img, source=source)
+    coregister_and_extract_data(img, non_linear_coreg=cfg.non_linear_coreg)
 
-        combine_data_with_empty_labels(layout_out, mask_name)
+    deepmreye_mask_report = get_deepmreye_filename(layout_in, img=img, filetype="report")
+    move_file(deepmreye_mask_report, report_name)
+
+    deepmreye_mask_name = get_deepmreye_filename(layout_in, img=img, filetype="mask")
+    move_file(deepmreye_mask_name, mask_name)
+
+    source = str(Path(img).relative_to(layout_in.root))
+    save_sampling_frequency_to_json(layout_out, img=img, source=source)
+
+    combine_data_with_empty_labels(layout_out, mask_name)
+    file_to_move = Path(layout_out.root).joinpath("..", "bidsmreye", output_file.name)
+    move_file(file_to_move, output_file)
 
 
 def prepare_data(cfg: Config) -> None:
@@ -167,8 +184,6 @@ def prepare_data(cfg: Config) -> None:
     :param cfg: Configuration object
     :type cfg: Config
     """
-    log.info("PREPARING DATA")
-
     layout_in = get_dataset_layout(
         cfg.input_dir,
         use_database=True,
@@ -181,8 +196,14 @@ def prepare_data(cfg: Config) -> None:
 
     subjects = list_subjects(cfg, layout_in)
 
+    text = "PREPARING DATA"
     if cfg.non_linear_coreg:
-        log.debug("Using non-linear coregistration")
+        log.info("Using non-linear coregistration")
 
-    for subject_label in subjects:
-        process_subject(cfg, layout_in, layout_out, subject_label)
+    with progress_bar(text=text) as progress:
+        subject_loop = progress.add_task(
+            description="processing subject", total=len(subjects)
+        )
+        for subject_label in subjects:
+            process_subject(cfg, layout_in, layout_out, subject_label)
+            progress.update(subject_loop, advance=1)

--- a/bidsmreye/prepare_data.py
+++ b/bidsmreye/prepare_data.py
@@ -95,7 +95,7 @@ def combine_data_with_empty_labels(layout_out: BIDSLayout, img: Path, i: int = 1
     subj["ids"].append(([entities["subject"]] * labels.shape[0], [i] * labels.shape[0]))
 
     output_file = create_bidsname(layout_out, Path(img), "no_label")
-    file_to_move = Path(layout_out.root).joinpath("..", "bidsmreye", output_file.name)
+    file_to_move = Path(layout_out.root) / ".." / "bidsmreye" / output_file.name
 
     preprocess.save_data(
         output_file.name,
@@ -177,7 +177,7 @@ def prepapre_image(
     save_sampling_frequency_to_json(layout_out, img=img, source=source)
 
     combine_data_with_empty_labels(layout_out, mask_name)
-    file_to_move = Path(layout_out.root).joinpath("..", "bidsmreye", output_file.name)
+    file_to_move = Path(layout_out.root) / ".." / "bidsmreye" / output_file.name
     move_file(file_to_move, output_file)
 
 

--- a/bidsmreye/utils.py
+++ b/bidsmreye/utils.py
@@ -42,12 +42,12 @@ def copy_license(output_dir: Path) -> Path:
     :param output_dir:
     :type output_dir: Path
     """
-    input_file = str(Path(__file__).parent.joinpath("templates", "CCO"))
-    output_file = output_dir.joinpath("LICENSE")
+    input_file = str(Path(__file__).parent / "templates" / "CCO")
+    output_file = output_dir / "LICENSE"
     create_dir_if_absent(output_dir)
-    if not output_dir.joinpath("LICENSE").is_file():
+    if not (output_dir / "LICENSE").is_file():
         shutil.copy(input_file, output_dir)
-        move_file(output_dir.joinpath("CCO"), output_file)
+        move_file(output_dir / "CCO", output_file)
     return output_file
 
 
@@ -59,7 +59,7 @@ def add_sidecar_in_root(layout_out: BIDSLayout) -> None:
         "SampleCoordinateSystem": "gaze-on-screen",
         "RecordedEye": "both",
     }
-    sidecar_name = Path(layout_out.root).joinpath("desc-bidsmreye_eyetrack.json")
+    sidecar_name = Path(layout_out.root) / "desc-bidsmreye_eyetrack.json"
     json.dump(content, open(sidecar_name, "w"), indent=4)
 
 
@@ -187,10 +187,7 @@ def get_deepmreye_filename(
 
     filename = return_deepmreye_output_filename(filename, filetype)
 
-    filefolder = Path(img).parent
-    filefolder = filefolder.joinpath(filename)
-
-    return Path(filefolder).absolute()
+    return Path(img).parent.absolute() / filename
 
 
 def return_deepmreye_output_filename(filename: str, filetype: str | None = None) -> str:

--- a/bidsmreye/utils.py
+++ b/bidsmreye/utils.py
@@ -7,11 +7,33 @@ from pathlib import Path
 from typing import Any
 
 from bids import BIDSLayout  # type: ignore
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
 
 from bidsmreye.configuration import Config
 from bidsmreye.logging import bidsmreye_log
 
 log = bidsmreye_log(name="bidsmreye")
+
+
+def progress_bar(text: str, color: str = "green") -> Progress:
+    return Progress(
+        TextColumn(f"[{color}]{text}"),
+        SpinnerColumn("dots"),
+        TimeElapsedColumn(),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TaskProgressColumn(),
+        TimeRemainingColumn(),
+    )
 
 
 def copy_license(output_dir: Path) -> Path:
@@ -80,7 +102,7 @@ def move_file(input: Path, output: Path) -> None:
     :param root: Optional. If specified, the printed path will be relative to this path.
     :type root: Path
     """
-    log.debug(f"{input.resolve()} --> {output.resolve()}")
+    log.debug(f"{input.absolute()} --> {output.absolute()}")
     create_dir_for_file(output)
     shutil.copy(input, output)
     input.unlink()
@@ -105,7 +127,7 @@ def create_dir_for_file(file: Path) -> None:
     :param file:
     :type file: Path
     """
-    output_path = file.resolve().parent
+    output_path = file.absolute().parent
     create_dir_if_absent(output_path)
 
     # TODO refactor with create_dir_if_absent
@@ -168,7 +190,7 @@ def get_deepmreye_filename(
     filefolder = Path(img).parent
     filefolder = filefolder.joinpath(filename)
 
-    return Path(filefolder).resolve()
+    return Path(filefolder).absolute()
 
 
 def return_deepmreye_output_filename(filename: str, filetype: str | None = None) -> str:

--- a/bidsmreye/visualize.py
+++ b/bidsmreye/visualize.py
@@ -39,7 +39,7 @@ COLORS = [COLOR_1, COLOR_2, COLOR_3]
 log = bidsmreye_log(name="bidsmreye")
 
 
-def collect_group_qc_data(cfg: Config) -> pd.DataFrame:
+def collect_group_qc_data(cfg: Config) -> pd.DataFrame | None:
     """Collect QC metrics data from all subjects json in a BIDS dataset.
 
     :param input_dir:
@@ -75,6 +75,9 @@ def collect_group_qc_data(cfg: Config) -> pd.DataFrame:
         df["subject"] = entities["subject"]
         qc_data = df if i == 0 else pd.concat([qc_data, df], sort=False)
 
+    if qc_data is None:
+        return None
+
     cols = [
         "subject",
         "filename",
@@ -84,7 +87,7 @@ def collect_group_qc_data(cfg: Config) -> pd.DataFrame:
         "eye1XVar",
         "eye1YVar",
     ]
-    qc_data = qc_data[cols]  # type: ignore
+    qc_data = qc_data[cols]
 
     return qc_data
 
@@ -132,6 +135,10 @@ def group_report(cfg: Config) -> None:
     :rtype: Any
     """
     qc_data = collect_group_qc_data(cfg)
+
+    if qc_data is None:
+        log.warning("No data found.")
+        return
 
     fig = go.FigureWidget(
         make_subplots(

--- a/bidsmreye/visualize.py
+++ b/bidsmreye/visualize.py
@@ -236,10 +236,10 @@ def group_report(cfg: Config) -> None:
     )
 
     fig.show()
-    group_report_file = Path(cfg.output_dir).joinpath("group_eyetrack.html")
+    group_report_file = cfg.output_dir / "group_eyetrack.html"
     fig.write_html(group_report_file)
 
-    qc_data_file = Path(cfg.output_dir).joinpath("group_eyetrack.tsv")
+    qc_data_file = cfg.output_dir / "group_eyetrack.tsv"
     qc_data.to_csv(qc_data_file, sep="\t", index=False)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "kaleido",
     "pooch>=1.6.0",
     "pybids",
-    "rich",
     "tqdm",
     "tomli; python_version < '3.11'",
     "keras<3.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ def create_basic_data():
     }
 
 
+@pytest.fixture
 def create_basic_json():
     output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
@@ -36,9 +37,7 @@ def create_basic_json():
 
 
 @pytest.fixture
-def create_confounds_tsv(create_data_with_outliers):
-    confounds_tsv = return_bidsmreye_eyetrack_tsv()
-
+def create_confounds_tsv(create_data_with_outliers, bidsmreye_eyetrack_tsv):
     df = pd.DataFrame(create_data_with_outliers)
 
     df["displacement"] = compute_displacement(
@@ -59,7 +58,7 @@ def create_confounds_tsv(create_data_with_outliers):
     cols.insert(0, cols.pop(cols.index("eye_timestamp")))
     df = df[cols]
 
-    df.to_csv(confounds_tsv, sep="\t", index=False)
+    df.to_csv(bidsmreye_eyetrack_tsv, sep="\t", index=False)
 
 
 @pytest.fixture
@@ -88,7 +87,8 @@ def pybids_test_dataset():
     return Path(get_test_data_path()).joinpath("synthetic", "derivatives", "fmriprep")
 
 
-def return_bidsmreye_eyetrack_tsv():
+@pytest.fixture
+def bidsmreye_eyetrack_tsv():
     output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,31 @@ from bidsmreye.quality_control import compute_displacement, compute_robust_outli
 
 
 @pytest.fixture
+def pybids_test_dataset() -> Path:
+    return Path(get_test_data_path()) / "synthetic" / "derivatives" / "fmriprep"
+
+
+@pytest.fixture
+def data_dir():
+    return Path(__file__).parent / "data"
+
+
+@pytest.fixture
+def output_dir(data_dir):
+    return data_dir / "bidsmreye"
+
+
+@pytest.fixture
+def bidsmreye_eyetrack_tsv(output_dir):
+    return (
+        output_dir
+        / "sub-01"
+        / "func"
+        / "sub-01_task-nback_space-MNI152NLin2009cAsym_desc-bidsmreye_eyetrack.tsv"
+    )
+
+
+@pytest.fixture
 def create_basic_data():
     return {
         "eye1_x_coordinate": np.random.randn(400),
@@ -21,14 +46,12 @@ def create_basic_data():
 
 
 @pytest.fixture
-def create_basic_json():
-    output_dir = Path().absolute()
-    output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
-
-    sidecar_name = output_dir.joinpath(
-        "sub-01",
-        "func",
-        "sub-01_task-nback_space-MNI152NLin2009cAsym_desc-bidsmreye_eyetrack.json",
+def create_basic_json(output_dir):
+    sidecar_name = (
+        output_dir
+        / "sub-01"
+        / "func"
+        / "sub-01_task-nback_space-MNI152NLin2009cAsym_desc-bidsmreye_eyetrack.json"
     )
 
     content = {"SamplingFrequency": 0.14285714285714285}
@@ -80,23 +103,6 @@ def create_data_with_outliers(create_basic_data):
     data["eye1_y_coordinate"][50] = eye1_y_coordinate.mean() + eye1_y_coordinate.std() * 4
 
     return data
-
-
-@pytest.fixture
-def pybids_test_dataset():
-    return Path(get_test_data_path()).joinpath("synthetic", "derivatives", "fmriprep")
-
-
-@pytest.fixture
-def bidsmreye_eyetrack_tsv():
-    output_dir = Path().absolute()
-    output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
-
-    return output_dir.joinpath(
-        "sub-01",
-        "func",
-        "sub-01_task-nback_space-MNI152NLin2009cAsym_desc-bidsmreye_eyetrack.tsv",
-    )
 
 
 def rm_dir(some_dir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 from bids.tests import get_test_data_path
 
 from bidsmreye.quality_control import compute_displacement, compute_robust_outliers
@@ -79,6 +80,7 @@ def create_data_with_outliers():
     return data
 
 
+@pytest.fixture
 def pybids_test_dataset():
     return Path(get_test_data_path()).joinpath("synthetic", "derivatives", "fmriprep")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from bids.tests import get_test_data_path
 from bidsmreye.quality_control import compute_displacement, compute_robust_outliers
 
 
+@pytest.fixture
 def create_basic_data():
     return {
         "eye1_x_coordinate": np.random.randn(400),
@@ -34,10 +35,11 @@ def create_basic_json():
     json.dump(content, open(sidecar_name, "w"), indent=4)
 
 
-def create_confounds_tsv():
+@pytest.fixture
+def create_confounds_tsv(create_data_with_outliers):
     confounds_tsv = return_bidsmreye_eyetrack_tsv()
 
-    df = pd.DataFrame(create_data_with_outliers())
+    df = pd.DataFrame(create_data_with_outliers)
 
     df["displacement"] = compute_displacement(
         df["eye1_x_coordinate"],
@@ -60,8 +62,9 @@ def create_confounds_tsv():
     df.to_csv(confounds_tsv, sep="\t", index=False)
 
 
-def create_data_with_outliers():
-    data = create_basic_data()
+@pytest.fixture
+def create_data_with_outliers(create_basic_data):
+    data = create_basic_data
 
     data["eye_timestamp"] = np.arange(400)
 

--- a/tests/data/bidsmreye/sub-01/func/sub-01_task-nback_space-MNI152NLin2009cAsym_desc-bidsmreye_eyetrack.json
+++ b/tests/data/bidsmreye/sub-01/func/sub-01_task-nback_space-MNI152NLin2009cAsym_desc-bidsmreye_eyetrack.json
@@ -1,8 +1,3 @@
 {
-    "SamplingFrequency": 0.14285714285714285,
-    "NbDisplacementOutliers": 5.0,
-    "NbXOutliers": 2.0,
-    "NbYOutliers": 2.0,
-    "eye1XVar": 0.9617292851848753,
-    "eye1YVar": 1.0699594318785
+    "SamplingFrequency": 0.14285714285714285
 }

--- a/tests/test_bids_utils.py
+++ b/tests/test_bids_utils.py
@@ -17,8 +17,6 @@ from bidsmreye.configuration import Config
 from bidsmreye.prepare_data import save_sampling_frequency_to_json
 from bidsmreye.utils import set_this_filter
 
-from .utils import pybids_test_dataset
-
 
 def test_create_bidsname(tmp_path):
     output_dir = tmp_path / "derivatives"
@@ -45,34 +43,34 @@ def test_get_dataset_layout_smoke_test(tmp_path):
     get_dataset_layout(tmp_path / "data")
 
 
-def test_init_dataset(tmp_path):
+def test_init_dataset(tmp_path, pybids_test_dataset):
     output_dir = tmp_path / "derivatives"
 
     cfg = Config(
-        pybids_test_dataset(),
+        pybids_test_dataset,
         output_dir,
     )
 
     init_dataset(cfg)
 
 
-def test_list_subjects():
+def test_list_subjects(pybids_test_dataset):
     cfg = Config(
-        pybids_test_dataset(),
+        pybids_test_dataset,
         Path(__file__).parent.joinpath("data"),
     )
 
-    layout = get_dataset_layout(pybids_test_dataset())
+    layout = get_dataset_layout(pybids_test_dataset)
 
     subjects = list_subjects(cfg, layout)
     assert len(subjects) == 5
 
 
-def test_save_sampling_frequency_to_json():
-    layout_in = get_dataset_layout(pybids_test_dataset())
+def test_save_sampling_frequency_to_json(pybids_test_dataset):
+    layout_in = get_dataset_layout(pybids_test_dataset)
 
     cfg = Config(
-        pybids_test_dataset(),
+        pybids_test_dataset,
         Path(__file__).parent.joinpath("data"),
     )
 
@@ -91,9 +89,9 @@ def test_save_sampling_frequency_to_json():
     assert content["Sources"][0] == "foo"
 
 
-def test_check_layout_prepare_data():
+def test_check_layout_prepare_data(pybids_test_dataset):
     cfg = Config(
-        pybids_test_dataset(),
+        pybids_test_dataset,
         Path(__file__).parent.joinpath("data"),
     )
 
@@ -106,8 +104,8 @@ def test_check_layout_prepare_data():
     check_layout(cfg, layout_in)
 
 
-def test_check_layout_error_no_space_entity(tmp_path):
-    shutil.copytree(pybids_test_dataset(), tmp_path, dirs_exist_ok=True)
+def test_check_layout_error_no_space_entity(tmp_path, pybids_test_dataset):
+    shutil.copytree(pybids_test_dataset, tmp_path, dirs_exist_ok=True)
     for file in tmp_path.rglob("*_space-*"):
         file.unlink()
 

--- a/tests/test_bids_utils.py
+++ b/tests/test_bids_utils.py
@@ -22,20 +22,25 @@ def test_create_bidsname(tmp_path):
     output_dir = tmp_path / "derivatives"
 
     layout = get_dataset_layout(output_dir)
-    filename = Path("inputs").joinpath(
-        "raw",
-        "sub-01",
-        "ses-01",
-        "func",
-        "sub-01_ses-01_task-motion_run-01_bold.nii",
+    filename = (
+        Path("inputs")
+        / "raw"
+        / "sub-01"
+        / "ses-01"
+        / "func"
+        / "sub-01_ses-01_task-motion_run-01_bold.nii"
     )
 
     output_file = create_bidsname(layout, filename=filename, filetype="mask")
 
     rel_path = output_file.relative_to(layout.root)
 
-    assert rel_path == Path("sub-01").joinpath(
-        "ses-01", "func", "sub-01_ses-01_task-motion_run-01_desc-eye_mask.p"
+    assert (
+        rel_path
+        == Path("sub-01")
+        / "ses-01"
+        / "func"
+        / "sub-01_ses-01_task-motion_run-01_desc-eye_mask.p"
     )
 
 
@@ -54,10 +59,10 @@ def test_init_dataset(tmp_path, pybids_test_dataset):
     init_dataset(cfg)
 
 
-def test_list_subjects(pybids_test_dataset):
+def test_list_subjects(data_dir, pybids_test_dataset):
     cfg = Config(
         pybids_test_dataset,
-        Path(__file__).parent.joinpath("data"),
+        data_dir,
     )
 
     layout = get_dataset_layout(pybids_test_dataset)
@@ -66,12 +71,12 @@ def test_list_subjects(pybids_test_dataset):
     assert len(subjects) == 5
 
 
-def test_save_sampling_frequency_to_json(pybids_test_dataset):
+def test_save_sampling_frequency_to_json(data_dir, pybids_test_dataset):
     layout_in = get_dataset_layout(pybids_test_dataset)
 
     cfg = Config(
         pybids_test_dataset,
-        Path(__file__).parent.joinpath("data"),
+        data_dir,
     )
 
     this_filter = set_this_filter(cfg, "01", "bold")
@@ -89,10 +94,10 @@ def test_save_sampling_frequency_to_json(pybids_test_dataset):
     assert content["Sources"][0] == "foo"
 
 
-def test_check_layout_prepare_data(pybids_test_dataset):
+def test_check_layout_prepare_data(data_dir, pybids_test_dataset):
     cfg = Config(
         pybids_test_dataset,
-        Path(__file__).parent.joinpath("data"),
+        data_dir,
     )
 
     layout_in = get_dataset_layout(

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -12,26 +12,24 @@ from bidsmreye.configuration import (
     get_pybids_config,
 )
 
-from .utils import pybids_test_dataset
 
-
-def test_Config():
+def test_Config(pybids_test_dataset):
     cfg = Config(
-        pybids_test_dataset(),
+        pybids_test_dataset,
         Path(__file__).parent.joinpath("data"),
     )
     assert not cfg.debug
     assert not cfg.non_linear_coreg
-    assert cfg.input_dir == pybids_test_dataset()
+    assert cfg.input_dir == pybids_test_dataset
     assert cfg.output_dir == Path(__file__).parent.joinpath("data", "bidsmreye")
     assert sorted(cfg.subjects) == ["01", "02", "03", "04", "05"]
     assert sorted(cfg.task) == ["nback", "rest"]
     assert sorted(cfg.space) == ["MNI152NLin2009cAsym", "T1w"]
 
 
-def test_config_to_dict_smoke():
+def test_config_to_dict_smoke(pybids_test_dataset):
     cfg = Config(
-        pybids_test_dataset(),
+        pybids_test_dataset,
         Path(__file__).parent.joinpath("data"),
     )
     config_to_dict(cfg)
@@ -52,54 +50,54 @@ def test_get_pybids_config_smoke():
     assert cfg is not None
 
 
-def test_missing_subject():
+def test_missing_subject(pybids_test_dataset):
     with pytest.warns(UserWarning):
         Config(
-            pybids_test_dataset(),
+            pybids_test_dataset,
             Path(__file__).parent.joinpath("data"),
             subjects=["01", "07"],
         )
 
 
-def test_missing_task():
+def test_missing_task(pybids_test_dataset):
     with pytest.warns(UserWarning):
         Config(
-            pybids_test_dataset(),
+            pybids_test_dataset,
             Path(__file__).parent.joinpath("data"),
             task=["auditory", "rest"],
         )
 
 
-def test_no_subject():
+def test_no_subject(pybids_test_dataset):
     with pytest.raises(RuntimeError):
         Config(
-            pybids_test_dataset(),
+            pybids_test_dataset,
             Path(__file__).parent.joinpath("data"),
             subjects=["99"],
         )
 
 
-def test_no_task():
+def test_no_task(pybids_test_dataset):
     with pytest.raises(RuntimeError):
         Config(
-            pybids_test_dataset(),
+            pybids_test_dataset,
             Path(__file__).parent.joinpath("data"),
             task=["foo"],
         )
 
 
-def test_missing_space():
+def test_missing_space(pybids_test_dataset):
     with pytest.warns(UserWarning):
         Config(
-            pybids_test_dataset(),
+            pybids_test_dataset,
             Path(__file__).parent.joinpath("data"),
             space=["T1w", "T2w"],
         )
 
 
-def test_task_omit_missing_values():
+def test_task_omit_missing_values(pybids_test_dataset):
     cfg = Config(
-        pybids_test_dataset(),
+        pybids_test_dataset,
         Path(__file__).parent.joinpath("data"),
         task=["auditory", "rest"],
         subjects=["01", "07"],

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from bidsmreye.configuration import (
@@ -13,24 +11,24 @@ from bidsmreye.configuration import (
 )
 
 
-def test_Config(pybids_test_dataset):
+def test_Config(data_dir, pybids_test_dataset):
     cfg = Config(
         pybids_test_dataset,
-        Path(__file__).parent.joinpath("data"),
+        data_dir,
     )
     assert not cfg.debug
     assert not cfg.non_linear_coreg
     assert cfg.input_dir == pybids_test_dataset
-    assert cfg.output_dir == Path(__file__).parent.joinpath("data", "bidsmreye")
+    assert cfg.output_dir == data_dir / "bidsmreye"
     assert sorted(cfg.subjects) == ["01", "02", "03", "04", "05"]
     assert sorted(cfg.task) == ["nback", "rest"]
     assert sorted(cfg.space) == ["MNI152NLin2009cAsym", "T1w"]
 
 
-def test_config_to_dict_smoke(pybids_test_dataset):
+def test_config_to_dict_smoke(data_dir, pybids_test_dataset):
     cfg = Config(
         pybids_test_dataset,
-        Path(__file__).parent.joinpath("data"),
+        data_dir,
     )
     config_to_dict(cfg)
 
@@ -50,55 +48,55 @@ def test_get_pybids_config_smoke():
     assert cfg is not None
 
 
-def test_missing_subject(pybids_test_dataset):
+def test_missing_subject(data_dir, pybids_test_dataset):
     with pytest.warns(UserWarning):
         Config(
             pybids_test_dataset,
-            Path(__file__).parent.joinpath("data"),
+            data_dir,
             subjects=["01", "07"],
         )
 
 
-def test_missing_task(pybids_test_dataset):
+def test_missing_task(data_dir, pybids_test_dataset):
     with pytest.warns(UserWarning):
         Config(
             pybids_test_dataset,
-            Path(__file__).parent.joinpath("data"),
+            data_dir,
             task=["auditory", "rest"],
         )
 
 
-def test_no_subject(pybids_test_dataset):
+def test_no_subject(data_dir, pybids_test_dataset):
     with pytest.raises(RuntimeError):
         Config(
             pybids_test_dataset,
-            Path(__file__).parent.joinpath("data"),
+            data_dir,
             subjects=["99"],
         )
 
 
-def test_no_task(pybids_test_dataset):
+def test_no_task(data_dir, pybids_test_dataset):
     with pytest.raises(RuntimeError):
         Config(
             pybids_test_dataset,
-            Path(__file__).parent.joinpath("data"),
+            data_dir,
             task=["foo"],
         )
 
 
-def test_missing_space(pybids_test_dataset):
+def test_missing_space(data_dir, pybids_test_dataset):
     with pytest.warns(UserWarning):
         Config(
             pybids_test_dataset,
-            Path(__file__).parent.joinpath("data"),
+            data_dir,
             space=["T1w", "T2w"],
         )
 
 
-def test_task_omit_missing_values(pybids_test_dataset):
+def test_task_omit_missing_values(data_dir, pybids_test_dataset):
     cfg = Config(
         pybids_test_dataset,
-        Path(__file__).parent.joinpath("data"),
+        data_dir,
         task=["auditory", "rest"],
         subjects=["01", "07"],
         space=["T1w", "T2w"],

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -19,10 +19,10 @@ def test_download_basic():
     download()
     output_file = download()
 
-    output_dir = Path.cwd().joinpath("models")
+    output_dir = Path.cwd() / "models"
     print(output_file)
     assert output_dir.is_dir()
-    assert output_dir.joinpath("dataset_1to6.h5").is_file()
+    assert (output_dir / "dataset_1to6.h5").is_file()
 
     shutil.rmtree(output_dir)
 

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -8,7 +8,7 @@ from bidsmreye.generalize import convert_confounds
 
 
 def test_convert_confounds():
-    output_dir = Path().resolve()
+    output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
 
     layout_out = get_dataset_layout(output_dir)

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1,22 +1,19 @@
 from __future__ import annotations
 
 import shutil
-from pathlib import Path
 
 from bidsmreye.bids_utils import get_dataset_layout
 from bidsmreye.generalize import convert_confounds
 
 
-def test_convert_confounds():
-    output_dir = Path().absolute()
-    output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
-
+def test_convert_confounds(output_dir):
     layout_out = get_dataset_layout(output_dir)
 
-    file = output_dir.joinpath(
-        "sub-01",
-        "func",
-        "sub-01_task-nback_space-MNI152NLin2009cAsym_desc-bidsmreye_confounds.npy",
+    file = (
+        output_dir
+        / "sub-01"
+        / "func"
+        / "sub-01_task-nback_space-MNI152NLin2009cAsym_desc-bidsmreye_confounds.npy"
     )
     shutil.copy(file, file.with_suffix(".bak"))
 

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -7,7 +7,7 @@ from bidsmreye.prepare_data import combine_data_with_empty_labels
 
 
 def test_combine_data_with_empty_labels():
-    output_dir = Path().resolve()
+    output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
 
     layout_out = get_dataset_layout(output_dir)

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from bidsmreye.bids_utils import get_dataset_layout
+from bidsmreye.bids_utils import create_bidsname, get_dataset_layout
 from bidsmreye.prepare_data import combine_data_with_empty_labels
 
 
@@ -20,14 +20,10 @@ def test_combine_data_with_empty_labels():
 
     no_label_file = combine_data_with_empty_labels(layout_out, file)
 
-    assert no_label_file.is_file()
+    assert no_label_file.exists()
 
-    expected_file = output_dir.joinpath(
-        "sub-01",
-        "func",
-        "sub-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-nolabel_bidsmreye.npz",
-    )
-
-    assert no_label_file == expected_file
+    output_file = create_bidsname(layout_out, file, "no_label")
+    file_to_move = Path(layout_out.root).joinpath("..", "bidsmreye", output_file.name)
+    assert no_label_file == file_to_move
 
     no_label_file.unlink()

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -6,16 +6,14 @@ from bidsmreye.bids_utils import create_bidsname, get_dataset_layout
 from bidsmreye.prepare_data import combine_data_with_empty_labels
 
 
-def test_combine_data_with_empty_labels():
-    output_dir = Path().absolute()
-    output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
-
+def test_combine_data_with_empty_labels(output_dir):
     layout_out = get_dataset_layout(output_dir)
 
-    file = output_dir.joinpath(
-        "sub-01",
-        "func",
-        "sub-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-eye_mask.p",
+    file = (
+        output_dir
+        / "sub-01"
+        / "func"
+        / "sub-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-eye_mask.p"
     )
 
     no_label_file = combine_data_with_empty_labels(layout_out, file)
@@ -23,7 +21,7 @@ def test_combine_data_with_empty_labels():
     assert no_label_file.exists()
 
     output_file = create_bidsname(layout_out, file, "no_label")
-    file_to_move = Path(layout_out.root).joinpath("..", "bidsmreye", output_file.name)
+    file_to_move = Path(layout_out.root) / ".." / "bidsmreye" / output_file.name
     assert no_label_file == file_to_move
 
     no_label_file.unlink()

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -46,9 +46,8 @@ def time_series():
     ]
 
 
-def test_get_sampling_frequency():
-    ds_location = Path().absolute().joinpath("tests", "data", "bidsmreye")
-    layout = get_dataset_layout(ds_location)
+def test_get_sampling_frequency(output_dir):
+    layout = get_dataset_layout(output_dir)
 
     file = layout.get(return_type="filename", suffix="eyetrack")[0]
 
@@ -58,8 +57,8 @@ def test_get_sampling_frequency():
 
 
 @pytest.mark.xfail(reason="not implemented yet")
-def test_get_sampling_frequency_in_root():
-    ds_location = Path().absolute().joinpath("tests", "data", "ds000201-der")
+def test_get_sampling_frequency_in_root(data_dir):
+    ds_location = data_dir / "ds000201-der"
     layout = get_dataset_layout(ds_location)
 
     file = layout.get(return_type="filename", subject="9001", suffix="eyetrack")[0]
@@ -111,24 +110,23 @@ def test_compute_robust_with_nan():
 
 
 def test_quality_control_output(
-    create_basic_data, create_basic_json, bidsmreye_eyetrack_tsv
+    create_basic_data, create_basic_json, bidsmreye_eyetrack_tsv, data_dir
 ):
-    output_dir = Path().absolute()
-    output_dir = output_dir.joinpath("tests", "data")
+    output_dir = data_dir
 
     df = pd.DataFrame(create_basic_data)
     df.to_csv(bidsmreye_eyetrack_tsv, sep="\t", index=False)
 
     cfg = Config(
-        output_dir.joinpath("bidsmreye"),
+        output_dir / "bidsmreye",
         output_dir,
     )
 
     quality_control_output(cfg)
 
 
-def test_quality_control_input(tmp_path):
-    input_dir = Path("tests") / "data" / "ds000201-der"
+def test_quality_control_input(tmp_path, data_dir):
+    input_dir = data_dir / "ds000201-der"
     output_dir = tmp_path / "derivatives"
 
     cfg = Config(
@@ -140,10 +138,12 @@ def test_quality_control_input(tmp_path):
 
 
 def test_perform_quality_control(
-    pybids_test_dataset, create_basic_data, create_basic_json, bidsmreye_eyetrack_tsv
+    output_dir,
+    pybids_test_dataset,
+    create_basic_data,
+    create_basic_json,
+    bidsmreye_eyetrack_tsv,
 ):
-    output_dir = Path().absolute()
-    output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
     layout = get_dataset_layout(output_dir)
 
     df = pd.DataFrame(create_basic_data)
@@ -151,17 +151,17 @@ def test_perform_quality_control(
 
     cfg = Config(
         pybids_test_dataset,
-        Path(__file__).parent.joinpath("data"),
+        Path(__file__).parent / "data",
     )
 
     perform_quality_control(cfg, layout, bidsmreye_eyetrack_tsv)
 
 
-def test_perform_quality_control_with_different_output(pybids_test_dataset):
-    input_dir = Path().absolute().joinpath("tests", "data", "ds000201-der")
+def test_perform_quality_control_with_different_output(data_dir, pybids_test_dataset):
+    input_dir = data_dir / "ds000201-der"
     layout_in = get_dataset_layout(input_dir)
 
-    output_dir = input_dir.joinpath("derivatives", "bidsmreye")
+    output_dir = input_dir / "derivatives" / "bidsmreye"
     layout_out = get_dataset_layout(output_dir)
 
     confounds_tsv = layout_in.get(
@@ -170,7 +170,7 @@ def test_perform_quality_control_with_different_output(pybids_test_dataset):
 
     cfg = Config(
         pybids_test_dataset,
-        Path(__file__).parent.joinpath("data"),
+        Path(__file__).parent / "data",
     )
 
     perform_quality_control(
@@ -181,10 +181,8 @@ def test_perform_quality_control_with_different_output(pybids_test_dataset):
 
 
 def test_add_qc_to_sidecar(
-    create_confounds_tsv, create_basic_json, bidsmreye_eyetrack_tsv
+    output_dir, create_confounds_tsv, create_basic_json, bidsmreye_eyetrack_tsv
 ):
-    output_dir = Path().absolute()
-    output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
     layout_out = get_dataset_layout(output_dir)
 
     confounds = pd.read_csv(bidsmreye_eyetrack_tsv, sep="\t")
@@ -194,8 +192,8 @@ def test_add_qc_to_sidecar(
     add_qc_to_sidecar(confounds, sidecar_name)
 
 
-def test_add_qc_to_sidecar_if_missing():
-    ds_location = Path().absolute().joinpath("tests", "data", "ds000201-der")
+def test_add_qc_to_sidecar_if_missing(data_dir):
+    ds_location = data_dir / "ds000201-der"
     layout = get_dataset_layout(ds_location)
 
     file = layout.get(

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -18,7 +18,7 @@ from bidsmreye.quality_control import (
     quality_control_output,
 )
 
-from .conftest import create_basic_json, return_bidsmreye_eyetrack_tsv, rm_dir
+from .conftest import rm_dir
 
 
 def time_series():
@@ -110,16 +110,14 @@ def test_compute_robust_with_nan():
     assert outliers == expected_outliers
 
 
-def test_quality_control_output(create_basic_data):
-    create_basic_json()
-
+def test_quality_control_output(
+    create_basic_data, create_basic_json, bidsmreye_eyetrack_tsv
+):
     output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data")
 
-    confounds_tsv = return_bidsmreye_eyetrack_tsv()
-
     df = pd.DataFrame(create_basic_data)
-    df.to_csv(confounds_tsv, sep="\t", index=False)
+    df.to_csv(bidsmreye_eyetrack_tsv, sep="\t", index=False)
 
     cfg = Config(
         output_dir.joinpath("bidsmreye"),
@@ -141,23 +139,22 @@ def test_quality_control_input(tmp_path):
     quality_control_input(cfg)
 
 
-def test_perform_quality_control(pybids_test_dataset, create_basic_data):
-    create_basic_json()
-
+def test_perform_quality_control(
+    pybids_test_dataset, create_basic_data, create_basic_json, bidsmreye_eyetrack_tsv
+):
     output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
     layout = get_dataset_layout(output_dir)
-    confounds_tsv = return_bidsmreye_eyetrack_tsv()
 
     df = pd.DataFrame(create_basic_data)
-    df.to_csv(confounds_tsv, sep="\t", index=False)
+    df.to_csv(bidsmreye_eyetrack_tsv, sep="\t", index=False)
 
     cfg = Config(
         pybids_test_dataset,
         Path(__file__).parent.joinpath("data"),
     )
 
-    perform_quality_control(cfg, layout, confounds_tsv)
+    perform_quality_control(cfg, layout, bidsmreye_eyetrack_tsv)
 
 
 def test_perform_quality_control_with_different_output(pybids_test_dataset):
@@ -183,17 +180,16 @@ def test_perform_quality_control_with_different_output(pybids_test_dataset):
     rm_dir(output_dir)
 
 
-def test_add_qc_to_sidecar(create_confounds_tsv):
-    create_basic_json()
-
+def test_add_qc_to_sidecar(
+    create_confounds_tsv, create_basic_json, bidsmreye_eyetrack_tsv
+):
     output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
     layout_out = get_dataset_layout(output_dir)
 
-    confounds_tsv = return_bidsmreye_eyetrack_tsv()
-    confounds = pd.read_csv(confounds_tsv, sep="\t")
+    confounds = pd.read_csv(bidsmreye_eyetrack_tsv, sep="\t")
 
-    sidecar_name = create_bidsname(layout_out, confounds_tsv, "confounds_json")
+    sidecar_name = create_bidsname(layout_out, bidsmreye_eyetrack_tsv, "confounds_json")
 
     add_qc_to_sidecar(confounds, sidecar_name)
 

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -53,7 +53,7 @@ def time_series():
 
 
 def test_get_sampling_frequency():
-    ds_location = Path().resolve().joinpath("tests", "data", "bidsmreye")
+    ds_location = Path().absolute().joinpath("tests", "data", "bidsmreye")
     layout = get_dataset_layout(ds_location)
 
     file = layout.get(return_type="filename", suffix="eyetrack")[0]
@@ -65,7 +65,7 @@ def test_get_sampling_frequency():
 
 @pytest.mark.xfail(reason="not implemented yet")
 def test_get_sampling_frequency_in_root():
-    ds_location = Path().resolve().joinpath("tests", "data", "ds000201-der")
+    ds_location = Path().absolute().joinpath("tests", "data", "ds000201-der")
     layout = get_dataset_layout(ds_location)
 
     file = layout.get(return_type="filename", subject="9001", suffix="eyetrack")[0]
@@ -119,7 +119,7 @@ def test_compute_robust_with_nan():
 def test_quality_control_output():
     create_basic_json()
 
-    output_dir = Path().resolve()
+    output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data")
 
     confounds_tsv = return_bidsmreye_eyetrack_tsv()
@@ -150,7 +150,7 @@ def test_quality_control_input(tmp_path):
 def test_perform_quality_control():
     create_basic_json()
 
-    output_dir = Path().resolve()
+    output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
     layout = get_dataset_layout(output_dir)
     confounds_tsv = return_bidsmreye_eyetrack_tsv()
@@ -158,11 +158,13 @@ def test_perform_quality_control():
     df = pd.DataFrame(create_basic_data())
     df.to_csv(confounds_tsv, sep="\t", index=False)
 
-    perform_quality_control(layout, confounds_tsv)
+    cfg = Config()
+
+    perform_quality_control(cfg, layout, confounds_tsv)
 
 
 def test_perform_quality_control_with_different_output():
-    input_dir = Path().resolve().joinpath("tests", "data", "ds000201-der")
+    input_dir = Path().absolute().joinpath("tests", "data", "ds000201-der")
     layout_in = get_dataset_layout(input_dir)
 
     output_dir = input_dir.joinpath("derivatives", "bidsmreye")
@@ -172,8 +174,10 @@ def test_perform_quality_control_with_different_output():
         return_type="filename", subject="9001", suffix="eyetrack", extension=".tsv"
     )[0]
 
+    cfg = Config()
+
     perform_quality_control(
-        layout_in=layout_in, confounds_tsv=confounds_tsv, layout_out=layout_out
+        cfg=cfg, layout_in=layout_in, confounds_tsv=confounds_tsv, layout_out=layout_out
     )
 
     rm_dir(output_dir)
@@ -184,7 +188,7 @@ def test_add_qc_to_sidecar():
 
     create_confounds_tsv()
 
-    output_dir = Path().resolve()
+    output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
     layout_out = get_dataset_layout(output_dir)
 
@@ -197,7 +201,7 @@ def test_add_qc_to_sidecar():
 
 
 def test_add_qc_to_sidecar_if_missing():
-    ds_location = Path().resolve().joinpath("tests", "data", "ds000201-der")
+    ds_location = Path().absolute().joinpath("tests", "data", "ds000201-der")
     layout = get_dataset_layout(ds_location)
 
     file = layout.get(

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -18,7 +18,7 @@ from bidsmreye.quality_control import (
     quality_control_output,
 )
 
-from .utils import (
+from .conftest import (
     create_basic_data,
     create_basic_json,
     create_confounds_tsv,

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -18,13 +18,7 @@ from bidsmreye.quality_control import (
     quality_control_output,
 )
 
-from .conftest import (
-    create_basic_data,
-    create_basic_json,
-    create_confounds_tsv,
-    return_bidsmreye_eyetrack_tsv,
-    rm_dir,
-)
+from .conftest import create_basic_json, return_bidsmreye_eyetrack_tsv, rm_dir
 
 
 def time_series():
@@ -116,7 +110,7 @@ def test_compute_robust_with_nan():
     assert outliers == expected_outliers
 
 
-def test_quality_control_output():
+def test_quality_control_output(create_basic_data):
     create_basic_json()
 
     output_dir = Path().absolute()
@@ -124,7 +118,7 @@ def test_quality_control_output():
 
     confounds_tsv = return_bidsmreye_eyetrack_tsv()
 
-    df = pd.DataFrame(create_basic_data())
+    df = pd.DataFrame(create_basic_data)
     df.to_csv(confounds_tsv, sep="\t", index=False)
 
     cfg = Config(
@@ -147,7 +141,7 @@ def test_quality_control_input(tmp_path):
     quality_control_input(cfg)
 
 
-def test_perform_quality_control():
+def test_perform_quality_control(pybids_test_dataset, create_basic_data):
     create_basic_json()
 
     output_dir = Path().absolute()
@@ -155,15 +149,18 @@ def test_perform_quality_control():
     layout = get_dataset_layout(output_dir)
     confounds_tsv = return_bidsmreye_eyetrack_tsv()
 
-    df = pd.DataFrame(create_basic_data())
+    df = pd.DataFrame(create_basic_data)
     df.to_csv(confounds_tsv, sep="\t", index=False)
 
-    cfg = Config()
+    cfg = Config(
+        pybids_test_dataset,
+        Path(__file__).parent.joinpath("data"),
+    )
 
     perform_quality_control(cfg, layout, confounds_tsv)
 
 
-def test_perform_quality_control_with_different_output():
+def test_perform_quality_control_with_different_output(pybids_test_dataset):
     input_dir = Path().absolute().joinpath("tests", "data", "ds000201-der")
     layout_in = get_dataset_layout(input_dir)
 
@@ -174,7 +171,10 @@ def test_perform_quality_control_with_different_output():
         return_type="filename", subject="9001", suffix="eyetrack", extension=".tsv"
     )[0]
 
-    cfg = Config()
+    cfg = Config(
+        pybids_test_dataset,
+        Path(__file__).parent.joinpath("data"),
+    )
 
     perform_quality_control(
         cfg=cfg, layout_in=layout_in, confounds_tsv=confounds_tsv, layout_out=layout_out
@@ -183,10 +183,8 @@ def test_perform_quality_control_with_different_output():
     rm_dir(output_dir)
 
 
-def test_add_qc_to_sidecar():
+def test_add_qc_to_sidecar(create_confounds_tsv):
     create_basic_json()
-
-    create_confounds_tsv()
 
     output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ def test_copy_license(tmp_path):
     license_file = copy_license(output_dir)
 
     assert license_file.is_file()
-    assert str(license_file) == str(output_dir.joinpath("LICENSE"))
+    assert str(license_file) == str(output_dir / "LICENSE")
 
     copy_license(output_dir)
 
@@ -27,14 +27,15 @@ def test_copy_license(tmp_path):
 def test_get_deepmreye_filename(pybids_test_dataset):
     layout = get_dataset_layout(pybids_test_dataset)
 
-    output_file = Path(pybids_test_dataset).joinpath(
-        "sub-01",
-        "ses-01",
-        "func",
-        (
+    output_file = (
+        Path(pybids_test_dataset)
+        / "sub-01"
+        / "ses-01"
+        / "func"
+        / (
             "mask_sub-01_ses-01_task-nback_run-01_"
             "space-MNI152NLin2009cAsym_desc-preproc_bold.p"
-        ),
+        )
     )
 
     img = layout.get(
@@ -70,10 +71,7 @@ def test_return_regex():
     assert return_regex(["foo", "bar"]) == "^foo$|^bar$"
 
 
-def test_set_this_filter_bold(pybids_test_dataset):
-    output_dir = Path().absolute()
-    output_dir = Path.joinpath(output_dir, "derivatives")
-
+def test_set_this_filter_bold(pybids_test_dataset, output_dir):
     cfg = Config(
         pybids_test_dataset,
         output_dir,
@@ -95,10 +93,7 @@ def test_set_this_filter_bold(pybids_test_dataset):
     }
 
 
-def test_set_this_filter_bidsmreye(pybids_test_dataset):
-    output_dir = Path().absolute()
-    output_dir = Path.joinpath(output_dir, "data", "bidsmreye")
-
+def test_set_this_filter_bidsmreye(output_dir, pybids_test_dataset):
     cfg = Config(pybids_test_dataset, output_dir, run="1")
 
     this_filter = set_this_filter(cfg, subject_label="001", filter_type="eyetrack")
@@ -114,7 +109,7 @@ def test_set_this_filter_bidsmreye(pybids_test_dataset):
     }
 
 
-def test_set_this_filter_with_bids_filter_file(pybids_test_dataset):
+def test_set_this_filter_with_bids_filter_file(output_dir, pybids_test_dataset):
     bids_filter = {
         "eyetrack": {
             "suffix": "^eyetrack$$",
@@ -122,9 +117,6 @@ def test_set_this_filter_with_bids_filter_file(pybids_test_dataset):
             "desc": "preproc",
         }
     }
-
-    output_dir = Path().absolute()
-    output_dir = Path.joinpath(output_dir, "data", "bidsmreye")
 
     cfg = Config(pybids_test_dataset, output_dir, run="1", bids_filter=bids_filter)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,8 +12,6 @@ from bidsmreye.utils import (
     set_this_filter,
 )
 
-from .utils import pybids_test_dataset
-
 
 def test_copy_license(tmp_path):
     output_dir = tmp_path / "derivatives"
@@ -26,10 +24,10 @@ def test_copy_license(tmp_path):
     copy_license(output_dir)
 
 
-def test_get_deepmreye_filename():
-    layout = get_dataset_layout(pybids_test_dataset())
+def test_get_deepmreye_filename(pybids_test_dataset):
+    layout = get_dataset_layout(pybids_test_dataset)
 
-    output_file = Path(pybids_test_dataset()).joinpath(
+    output_file = Path(pybids_test_dataset).joinpath(
         "sub-01",
         "ses-01",
         "func",
@@ -72,12 +70,12 @@ def test_return_regex():
     assert return_regex(["foo", "bar"]) == "^foo$|^bar$"
 
 
-def test_set_this_filter_bold():
+def test_set_this_filter_bold(pybids_test_dataset):
     output_dir = Path().absolute()
     output_dir = Path.joinpath(output_dir, "derivatives")
 
     cfg = Config(
-        pybids_test_dataset(),
+        pybids_test_dataset,
         output_dir,
     )
 
@@ -97,11 +95,11 @@ def test_set_this_filter_bold():
     }
 
 
-def test_set_this_filter_bidsmreye():
+def test_set_this_filter_bidsmreye(pybids_test_dataset):
     output_dir = Path().absolute()
     output_dir = Path.joinpath(output_dir, "data", "bidsmreye")
 
-    cfg = Config(pybids_test_dataset(), output_dir, run="1")
+    cfg = Config(pybids_test_dataset, output_dir, run="1")
 
     this_filter = set_this_filter(cfg, subject_label="001", filter_type="eyetrack")
 
@@ -116,7 +114,7 @@ def test_set_this_filter_bidsmreye():
     }
 
 
-def test_set_this_filter_with_bids_filter_file():
+def test_set_this_filter_with_bids_filter_file(pybids_test_dataset):
     bids_filter = {
         "eyetrack": {
             "suffix": "^eyetrack$$",
@@ -128,7 +126,7 @@ def test_set_this_filter_with_bids_filter_file():
     output_dir = Path().absolute()
     output_dir = Path.joinpath(output_dir, "data", "bidsmreye")
 
-    cfg = Config(pybids_test_dataset(), output_dir, run="1", bids_filter=bids_filter)
+    cfg = Config(pybids_test_dataset, output_dir, run="1", bids_filter=bids_filter)
 
     this_filter = set_this_filter(cfg, subject_label="001", filter_type="eyetrack")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,7 +73,7 @@ def test_return_regex():
 
 
 def test_set_this_filter_bold():
-    output_dir = Path().resolve()
+    output_dir = Path().absolute()
     output_dir = Path.joinpath(output_dir, "derivatives")
 
     cfg = Config(
@@ -98,7 +98,7 @@ def test_set_this_filter_bold():
 
 
 def test_set_this_filter_bidsmreye():
-    output_dir = Path().resolve()
+    output_dir = Path().absolute()
     output_dir = Path.joinpath(output_dir, "data", "bidsmreye")
 
     cfg = Config(pybids_test_dataset(), output_dir, run="1")
@@ -125,7 +125,7 @@ def test_set_this_filter_with_bids_filter_file():
         }
     }
 
-    output_dir = Path().resolve()
+    output_dir = Path().absolute()
     output_dir = Path.joinpath(output_dir, "data", "bidsmreye")
 
     cfg = Config(pybids_test_dataset(), output_dir, run="1", bids_filter=bids_filter)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -8,7 +8,7 @@ from bidsmreye.bidsmreye import bidsmreye
 from bidsmreye.configuration import Config
 from bidsmreye.visualize import group_report, visualize_eye_gaze_data
 
-from .utils import create_confounds_tsv, return_bidsmreye_eyetrack_tsv
+from .conftest import create_confounds_tsv, return_bidsmreye_eyetrack_tsv
 
 
 def test_visualize_eye_gaze_data():

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -24,7 +24,7 @@ def test_visualize_eye_gaze_data():
 
 
 def test_group_report():
-    input_dir = Path().resolve().joinpath("tests", "data", "derivatives", "bidsmreye")
+    input_dir = Path().absolute().joinpath("tests", "data", "derivatives", "bidsmreye")
 
     cfg = Config(
         input_dir=input_dir,
@@ -35,7 +35,7 @@ def test_group_report():
 
 
 def test_group_report_cli():
-    bids_dir = Path().resolve().joinpath("tests", "data", "derivatives", "bidsmreye")
+    bids_dir = Path().absolute().joinpath("tests", "data", "derivatives", "bidsmreye")
 
     bidsmreye(
         bids_dir=bids_dir,

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -8,13 +8,9 @@ from bidsmreye.bidsmreye import bidsmreye
 from bidsmreye.configuration import Config
 from bidsmreye.visualize import group_report, visualize_eye_gaze_data
 
-from .conftest import return_bidsmreye_eyetrack_tsv
 
-
-def test_visualize_eye_gaze_data(create_confounds_tsv):
-    confounds_tsv = return_bidsmreye_eyetrack_tsv()
-
-    eye_gaze_data = pd.read_csv(confounds_tsv, sep="\t")
+def test_visualize_eye_gaze_data(create_confounds_tsv, bidsmreye_eyetrack_tsv):
+    eye_gaze_data = pd.read_csv(bidsmreye_eyetrack_tsv, sep="\t")
 
     fig = visualize_eye_gaze_data(eye_gaze_data)
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shutil
+
 import pandas as pd
 
 from bidsmreye.bidsmreye import bidsmreye
@@ -9,30 +11,41 @@ from bidsmreye.visualize import group_report, visualize_eye_gaze_data
 
 def test_visualize_eye_gaze_data(create_confounds_tsv, bidsmreye_eyetrack_tsv):
     eye_gaze_data = pd.read_csv(bidsmreye_eyetrack_tsv, sep="\t")
-
     fig = visualize_eye_gaze_data(eye_gaze_data)
-
     fig.show()
 
 
-def test_group_report(create_confounds_tsv, output_dir):
-    input_dir = output_dir
+def test_group_report(tmp_path, data_dir):
+    src_dir = data_dir / "derivatives" / "bidsmreye"
+    target_dir = tmp_path / "bidsmreye"
+    target_dir.mkdir()
+    shutil.copytree(src_dir, target_dir, dirs_exist_ok=True)
 
     cfg = Config(
-        input_dir=input_dir,
-        output_dir=input_dir.parent,
+        input_dir=target_dir,
+        output_dir=target_dir.parent,
     )
 
     group_report(cfg)
 
+    assert (target_dir / "group_eyetrack.html").exists()
+    assert (target_dir / "group_eyetrack.tsv").exists()
 
-def test_group_report_cli(data_dir):
-    bids_dir = data_dir / "ds000201-der"
+
+def test_group_report_cli(tmp_path, data_dir):
+
+    src_dir = data_dir / "derivatives" / "bidsmreye"
+    target_dir = tmp_path / "bidsmreye"
+    target_dir.mkdir()
+    shutil.copytree(src_dir, target_dir, dirs_exist_ok=True)
 
     bidsmreye(
-        bids_dir=bids_dir,
-        output_dir=bids_dir.parent,
+        bids_dir=target_dir,
+        output_dir=target_dir.parent,
         analysis_level="group",
         action="qc",
         participant_label=["9001", "9008"],
     )
+
+    assert (target_dir / "group_eyetrack.html").exists()
+    assert (target_dir / "group_eyetrack.tsv").exists()

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -8,13 +8,11 @@ from bidsmreye.bidsmreye import bidsmreye
 from bidsmreye.configuration import Config
 from bidsmreye.visualize import group_report, visualize_eye_gaze_data
 
-from .conftest import create_confounds_tsv, return_bidsmreye_eyetrack_tsv
+from .conftest import return_bidsmreye_eyetrack_tsv
 
 
-def test_visualize_eye_gaze_data():
+def test_visualize_eye_gaze_data(create_confounds_tsv):
     confounds_tsv = return_bidsmreye_eyetrack_tsv()
-
-    create_confounds_tsv()
 
     eye_gaze_data = pd.read_csv(confounds_tsv, sep="\t")
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pandas as pd
 
 from bidsmreye.bidsmreye import bidsmreye
@@ -17,8 +15,8 @@ def test_visualize_eye_gaze_data(create_confounds_tsv, bidsmreye_eyetrack_tsv):
     fig.show()
 
 
-def test_group_report():
-    input_dir = Path().absolute().joinpath("tests", "data", "derivatives", "bidsmreye")
+def test_group_report(create_confounds_tsv, output_dir):
+    input_dir = output_dir
 
     cfg = Config(
         input_dir=input_dir,
@@ -28,8 +26,8 @@ def test_group_report():
     group_report(cfg)
 
 
-def test_group_report_cli():
-    bids_dir = Path().absolute().joinpath("tests", "data", "derivatives", "bidsmreye")
+def test_group_report_cli(data_dir):
+    bids_dir = data_dir / "ds000201-der"
 
     bidsmreye(
         bids_dir=bids_dir,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,7 @@ def create_basic_data():
 
 
 def create_basic_json():
-    output_dir = Path().resolve()
+    output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
 
     sidecar_name = output_dir.joinpath(
@@ -84,7 +84,7 @@ def pybids_test_dataset():
 
 
 def return_bidsmreye_eyetrack_tsv():
-    output_dir = Path().resolve()
+    output_dir = Path().absolute()
     output_dir = output_dir.joinpath("tests", "data", "bidsmreye")
 
     return output_dir.joinpath(


### PR DESCRIPTION
- closes #168
- add a `--force` option to the CLI to overwrite previous results
 
Could not skip "generale" as the name of the output data is not yet directly predictable from input data.

---

Unrelated

- add rich progress bar over subjects
- clean up Path handling (remove `joinpath()`)
- use fixtures in tests