### PR TITLE
[FIX] do not apply run found for one task to all tasks

### DIFF
--- a/bidsmreye/bids_utils.py
+++ b/bidsmreye/bids_utils.py
@@ -17,7 +17,7 @@ from bidsmreye.configuration import (
 )
 from bidsmreye.logging import bidsmreye_log
 from bidsmreye.methods import methods
-from bidsmreye.utils import copy_license, create_dir_if_absent
+from bidsmreye.utils import copy_license, create_dir_if_absent, return_regex
 
 log = bidsmreye_log("bidsmreye")
 
@@ -60,9 +60,10 @@ def check_layout(cfg: Config, layout: BIDSLayout, for_file: str = "bold") -> Non
     if generated_by["Name"].lower() == "bidsmreye":
         this_filter = get_bids_filter_config()["mask"]
 
-    this_filter["task"] = cfg.task
-    this_filter["space"] = cfg.space
-    this_filter["run"] = cfg.run
+    this_filter["task"] = return_regex(cfg.task)
+    this_filter["space"] = return_regex(cfg.space) or ".*"
+    if cfg.run:
+        this_filter["run"] = cfg.run
 
     log.debug(f"Looking for files with filter\n{this_filter}")
 
@@ -78,8 +79,8 @@ def check_layout(cfg: Config, layout: BIDSLayout, for_file: str = "bold") -> Non
         raise RuntimeError(
             f"Input dataset {layout.root} does not have "
             f"any data to process for filter\n{this_filter}.\n"
-            f"This dataset contains subjects: {subjects}."
-            f"This dataset contains tasks: {tasks}."
+            f"This dataset contains subjects: {subjects}.\n"
+            f"This dataset contains tasks: {tasks}.\n"
             "Is your dataset a BIDS derivative dataset?\n"
             "Check the FAQ for more information: "
             "https://bidsmreye.readthedocs.io/en/latest/FAQ.html"

--- a/bidsmreye/bids_utils.py
+++ b/bidsmreye/bids_utils.py
@@ -61,7 +61,7 @@ def check_layout(cfg: Config, layout: BIDSLayout, for_file: str = "bold") -> Non
         this_filter = get_bids_filter_config()["mask"]
 
     this_filter["task"] = return_regex(cfg.task)
-    this_filter["space"] = return_regex(cfg.space) or ".*"
+    this_filter["space"] = cfg.space
     if cfg.run:
         this_filter["run"] = cfg.run
 

--- a/bidsmreye/bidsmreye.py
+++ b/bidsmreye/bidsmreye.py
@@ -102,14 +102,17 @@ def dispatch(analysis_level: str, action: str, cfg: Config) -> None:
 
             prepare_data(cfg)
             generalize(cfg)
+
         elif action == "prepare":
             from bidsmreye.prepare_data import prepare_data
 
             prepare_data(cfg)
+
         elif action == "generalize":
             from bidsmreye.generalize import generalize
 
             generalize(cfg)
+
         elif action == "qc":
             from bidsmreye.quality_control import quality_control_input
 

--- a/bidsmreye/configuration.py
+++ b/bidsmreye/configuration.py
@@ -105,8 +105,8 @@ No dataset_description.json found:
 
         self.check_argument(attribute="subjects", layout_in=layout_in)
         self.check_argument(attribute="task", layout_in=layout_in)
-        self.check_argument(attribute="run", layout_in=layout_in)
         self.check_argument(attribute="space", layout_in=layout_in)
+        self.check_argument(attribute="run", layout_in=layout_in)
 
     def check_argument(self, attribute: str, layout_in: BIDSLayout) -> Config:
         """Check an attribute value compared to the input dataset content.
@@ -125,9 +125,15 @@ No dataset_description.json found:
         if attribute == "subjects":
             value = layout_in.get_subjects()
         elif attribute == "task":
-            value = layout_in.get_tasks()
+            value = layout_in.get_tasks(subject=self.subjects)
         elif attribute in {"space", "run"}:
-            value = layout_in.get(return_type="id", target=attribute, datatype="func")
+            value = layout_in.get(
+                return_type="id",
+                target=attribute,
+                datatype="func",
+                subject=self.subjects,
+                task=self.task,
+            )
 
         self.listify(attribute)
 
@@ -148,9 +154,12 @@ No dataset_description.json found:
                 )
             value = list(set(getattr(self, attribute)) & set(value))
 
-        setattr(self, attribute, value)
-
         # run and space can be empty if their entity are not used
+        # we will figure out the values for run
+        # in subject / task wise manner later on
+        if attribute not in ["run"]:
+            setattr(self, attribute, value)
+
         if attribute not in ["run", "space"] and not getattr(self, attribute):
             raise RuntimeError(f"No {attribute} found in {self.input_dir}")
 

--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [FIX] do not apply run found for one task to all tasks by @Remi-Gau in https://github.com/cpp-lln-lab/bidsMReye/pull/228
+
 ### Security
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "kaleido",
     "pooch>=1.6.0",
     "pybids",
+    "antspyx<5",
     "tqdm",
     "tomli; python_version < '3.11'",
     "keras<3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "kaleido",
     "pooch>=1.6.0",
     "pybids",
-    "antspyx<5",
+    "antspyx<0.5",
     "tqdm",
     "tomli; python_version < '3.11'",
     "keras<3.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,9 @@ absl-py==2.1.0
     #   tensorboard
     #   tensorflow
 antspyx==0.4.2
-    # via deepmreye
+    # via
+    #   bidsmreye (pyproject.toml)
+    #   deepmreye
 anyio==4.4.0
     # via
     #   httpx
@@ -430,6 +432,8 @@ rfc3986-validator==0.1.1
     #   jsonschema
     #   jupyter-events
 rich==13.7.1
+    # via rich-argparse
+rich-argparse==1.5.2
     # via bidsmreye (pyproject.toml)
 rpds-py==0.19.1
     # via

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,7 +87,6 @@ def test_set_this_filter_bold(pybids_test_dataset, output_dir):
         "datatype": "func",
         "desc": "preproc",
         "extension": "nii.*",
-        "run": "1|2",
         "subject": "001",
         "suffix": "^bold$",
     }


### PR DESCRIPTION
in dataset with multiple tasks, if a task 'foo' has runs (say from 1 to 10) but another task 'bar' does not, the config was set to look for runs 1 to 10 in all tasks and would return no file for task 'bar' when preparing / generalysing data.